### PR TITLE
Solve input reference bug

### DIFF
--- a/src/pages/FaceDetection/FaceDetection.js
+++ b/src/pages/FaceDetection/FaceDetection.js
@@ -55,7 +55,7 @@ const FaceDetection = () => {
                 setDetectionData([]);
                 loader.current.setAttribute("data-show", "");
                 
-                const data = await onFormSubmit(imageInput);
+                const data = await onFormSubmit(imageInput.current);
                 if (!data || data.status === 'unauthorized' || data.status === 'fail') {
                     loader.current.removeAttribute("data-show");
                     return;


### PR DESCRIPTION
The file input wasn't referenced correctly when passed as an argument when calling the `onFormSubmit` function as it was passed as `ref` instead of `ref.current`.